### PR TITLE
raytracer: use lighter triangle class to reduce memory consumption

### DIFF
--- a/raytracer/CMakeLists.txt
+++ b/raytracer/CMakeLists.txt
@@ -37,6 +37,7 @@ set(BASE_SOURCE_FILES
 
     src/octree/octree.cc
     src/octree/leaf.cc
+    src/octree/node.cc
   )
 
 include_directories(include)

--- a/raytracer/CMakeLists.txt
+++ b/raytracer/CMakeLists.txt
@@ -23,6 +23,7 @@ set(BASE_SOURCE_FILES
     src/box.cc
     src/plane.cc
     src/mesh.cc
+    src/basic_triangle.cc
     src/triangle.cc
     src/image.cc
     src/input.cc

--- a/raytracer/include/basic_triangle.hh
+++ b/raytracer/include/basic_triangle.hh
@@ -18,8 +18,6 @@ public:
   friend std::istream& operator>>(std::istream& is, BasicTriangle& triangle);
   friend std::ostream& operator<<(std::ostream& os, const BasicTriangle& triangle);
 
-  friend class Triangle;
-
 private:
   Vector3 a;
   Vector3 b;

--- a/raytracer/include/basic_triangle.hh
+++ b/raytracer/include/basic_triangle.hh
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "vector3.hh"
+#include "ray.hh"
+
+#include <array>
+
+class BasicTriangle
+{
+public:
+  BasicTriangle() = default;
+  inline BasicTriangle(const Vector3& a, const Vector3& b, const Vector3& c);
+  inline Vector3 intersect(const Ray& ray) const;
+  inline std::array<Vector3, 3> get_vertices() const;
+  inline Vector3 normal_vect() const;
+  inline bool inside(const std::array<Vector3, 2> bounds) const;
+
+  friend std::istream& operator>>(std::istream& is, BasicTriangle& triangle);
+  friend std::ostream& operator<<(std::ostream& os, const BasicTriangle& triangle);
+
+  friend class Triangle;
+
+private:
+  Vector3 a;
+  Vector3 b;
+  Vector3 c;
+};
+
+std::istream& operator>>(std::istream& is, BasicTriangle& triangle);
+std::ostream& operator<<(std::ostream& os, const BasicTriangle& triangle);
+
+#include "basic_triangle.hxx"

--- a/raytracer/include/basic_triangle.hxx
+++ b/raytracer/include/basic_triangle.hxx
@@ -53,5 +53,16 @@ Vector3 BasicTriangle::intersect(const Ray& ray) const
 
 bool BasicTriangle::inside(const std::array<Vector3, 2> bounds) const
 {
-  return a.inside(bounds) || b.inside(bounds) || c.inside(bounds);
+  // Compute triangle's bounding box
+  double min_x = std::min({a.getX(), b.getX(), c.getX()});
+  double min_y = std::min({a.getY(), b.getY(), c.getY()});
+  double min_z = std::min({a.getZ(), b.getZ(), c.getZ()});
+  double max_x = std::max({a.getX(), b.getX(), c.getX()});
+  double max_y = std::max({a.getY(), b.getY(), c.getY()});
+  double max_z = std::max({a.getZ(), b.getZ(), c.getZ()});
+
+  // Check for AABB overlap
+  return (min_x <= bounds[1].getX() && max_x >= bounds[0].getX() &&
+          min_y <= bounds[1].getY() && max_y >= bounds[0].getY() &&
+          min_z <= bounds[1].getZ() && max_z >= bounds[0].getZ());
 }

--- a/raytracer/include/basic_triangle.hxx
+++ b/raytracer/include/basic_triangle.hxx
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "basic_triangle.hh"
+
+BasicTriangle::BasicTriangle(const Vector3& a, const Vector3& b,
+                             const Vector3& c)
+              : a(a), b(b), c(c)
+{}
+
+Vector3 BasicTriangle::normal_vect() const
+{
+  Vector3 ab = b - a;
+  Vector3 ac = c - a;
+  return ab * ac;
+}
+
+std::array<Vector3, 3> BasicTriangle::get_vertices() const
+{
+  std::array<Vector3, 3> vertices {{ a, b, c }};
+  return vertices;
+}
+
+// Use Möller-Trumbore intersection algorithm
+Vector3 BasicTriangle::intersect(const Ray& ray) const
+{
+  Vector3 ab = b - a;
+  Vector3 ac = c - a;
+  Vector3 pvec = ray.direction * ac;
+  double determinant = ab.dot_product(pvec);
+
+  if (std::abs(determinant) < epsilon)
+    return Vector3();
+
+  double inverse_determinant = 1. / determinant;
+
+  Vector3 tvec = ray.position - a;
+  double u = tvec.dot_product(pvec) * inverse_determinant;
+  if (u < 0 || u > 1)
+    return Vector3();
+
+  Vector3 qvec = tvec * ab;
+  double v = ray.direction.dot_product(qvec) * inverse_determinant;
+  if (v < 0 || u + v > 1)
+    return Vector3();
+
+  double t = ac.dot_product(qvec) * inverse_determinant;
+
+  if (t > epsilon)
+    return ray.direction * t + ray.position;
+
+  return Vector3();
+}
+
+bool BasicTriangle::inside(const std::array<Vector3, 2> bounds) const
+{
+  return a.inside(bounds) || b.inside(bounds) || c.inside(bounds);
+}

--- a/raytracer/include/box.hh
+++ b/raytracer/include/box.hh
@@ -27,25 +27,24 @@ protected:
 private:
   double scale;
   std::array<Vector3, 2> bounds;
-  std::array<Triangle, 12> triangles;
+  std::array<BasicTriangle, 12> triangles;
 
-  std::map<Vector3, const Triangle*> intersect_to_triangle;
+  std::map<Vector3, const BasicTriangle*> intersect_to_triangle;
 };
 
 std::istream& operator>>(std::istream& is, Box& box);
 std::ostream& operator<<(std::ostream& is, const Box& box);
 
-Vector3 box_intersect(const std::array<Triangle, 12>& triangles, const Ray& ray);
+Vector3 box_intersect(const std::array<BasicTriangle, 12>& triangles, const Ray& ray);
 bool box_is_intersecting(const Ray& ray, const std::array<Vector3, 2>& bounds);
 
 void calculate_box_triangles(const std::array<Vector3, 2>& bounds,
-                             std::array<Triangle, 12>& triangles,
-                             const Attributes& attr, const Color& color);
+                             std::array<BasicTriangle, 12>& triangles);
 
 template <typename T>
-std::pair<Vector3, const Triangle*> find_closest_intersection(T& triangles, const Ray& ray);
+std::pair<Vector3, const BasicTriangle*> find_closest_intersection(T& triangles, const Ray& ray);
 
 template <typename T>
-std::pair<Vector3, const Triangle*> find_closest_intersection_ptr(T& triangles, const Ray& ray);
+std::pair<Vector3, const BasicTriangle*> find_closest_intersection_ptr(T& triangles, const Ray& ray);
 
 #include "box.hxx"

--- a/raytracer/include/box.hxx
+++ b/raytracer/include/box.hxx
@@ -3,12 +3,12 @@
 #include "box.hh"
 
 template <typename T>
-std::pair<Vector3, const Triangle*> find_closest_intersection(T& triangles, const Ray& ray)
+std::pair<Vector3, const BasicTriangle*> find_closest_intersection(T& triangles, const Ray& ray)
 {
   Vector3 intersect;
-  const Triangle* min_triangle;
+  const BasicTriangle* min_triangle;
   double min_dist = INFINITY;
-  for (const Triangle& triangle: triangles)
+  for (const BasicTriangle& triangle: triangles)
   {
     Vector3 vect = triangle.intersect(ray);
     if (!vect)
@@ -26,12 +26,12 @@ std::pair<Vector3, const Triangle*> find_closest_intersection(T& triangles, cons
 }
 
 template <typename T>
-std::pair<Vector3, const Triangle*> find_closest_intersection_ptr(T& triangles, const Ray& ray)
+std::pair<Vector3, const BasicTriangle*> find_closest_intersection_ptr(T& triangles, const Ray& ray)
 {
   Vector3 intersect;
-  const Triangle* min_triangle;
+  const BasicTriangle* min_triangle;
   double min_dist = INFINITY;
-  for (const Triangle* triangle: triangles)
+  for (const BasicTriangle* triangle: triangles)
   {
     Vector3 vect = triangle->intersect(ray);
     if (!vect)

--- a/raytracer/include/mesh.hh
+++ b/raytracer/include/mesh.hh
@@ -15,7 +15,7 @@ public:
   virtual ~Mesh() = default;
   Mesh() = default;
   Mesh(const Vector3& pos, const Attributes& attr, const Color& color,
-       const std::vector<Triangle>& triangles);
+       const std::vector<BasicTriangle>& triangles);
   virtual Vector3 intersect(const Ray& ray) const override;
 
   friend std::istream& operator>>(std::istream& is, Mesh& mesh);
@@ -28,8 +28,8 @@ protected:
 private:
   void calculate_bounds();
 
-  std::vector<Triangle> triangles;
-  std::map<Vector3, const Triangle*> intersect_to_triangle;
+  std::vector<BasicTriangle> triangles;
+  std::map<Vector3, const BasicTriangle*> intersect_to_triangle;
   std::shared_ptr<Octree> octree;
 };
 

--- a/raytracer/include/octree/leaf.hh
+++ b/raytracer/include/octree/leaf.hh
@@ -6,6 +6,8 @@ class Leaf: public Node
 {
 public:
   virtual ~Leaf() = default;
+  Leaf(const std::vector<const BasicTriangle*>& triangles,
+       const std::array<Vector3, 2>& bounds);
   virtual void intersect(const Ray& ray, std::vector<const BasicTriangle*>& triangles) const;
 
 private:

--- a/raytracer/include/octree/leaf.hh
+++ b/raytracer/include/octree/leaf.hh
@@ -6,10 +6,10 @@ class Leaf: public Node
 {
 public:
   virtual ~Leaf() = default;
-  virtual void intersect(const Ray& ray, std::vector<const Triangle*>& triangles) const;
+  virtual void intersect(const Ray& ray, std::vector<const BasicTriangle*>& triangles) const;
 
 private:
   friend class Octree;
 
-  std::vector<const Triangle*> triangles;
+  std::vector<const BasicTriangle*> triangles;
 };

--- a/raytracer/include/octree/node.hh
+++ b/raytracer/include/octree/node.hh
@@ -11,7 +11,7 @@ class Node
 {
 public:
   virtual ~Node() = default;
-  virtual void intersect(const Ray& ray, std::vector<const Triangle*>& triangles) const = 0;
+  virtual void intersect(const Ray& ray, std::vector<const BasicTriangle*>& triangles) const = 0;
 
 protected:
   // can be recalculated

--- a/raytracer/include/octree/node.hh
+++ b/raytracer/include/octree/node.hh
@@ -10,7 +10,9 @@
 class Node
 {
 public:
+  Node() = default;
   virtual ~Node() = default;
+  Node(const std::array<Vector3, 2>& bounds);
   virtual void intersect(const Ray& ray, std::vector<const BasicTriangle*>& triangles) const = 0;
 
 protected:

--- a/raytracer/include/octree/octree.hh
+++ b/raytracer/include/octree/octree.hh
@@ -12,23 +12,23 @@ class Octree: public Node
 {
 public:
   virtual ~Octree() = default;
-  std::vector<const Triangle*> intersect(const Ray& ray) const;
+  std::vector<const BasicTriangle*> intersect(const Ray& ray) const;
   template <typename T>
   static Octree* build_octree(const T& triangles,
                               const std::array<Vector3, 2>& bounds,
                               const size_t depth = 9);
 
-  virtual void intersect(const Ray& ray, std::vector<const Triangle*>& triangles) const;
+  virtual void intersect(const Ray& ray, std::vector<const BasicTriangle*>& triangles) const override;
 
 private:
   static const size_t optimal_by_node = 5;
   std::array<std::unique_ptr<Node>, 8> children;
 };
 
-std::vector<const Triangle*> find_all_triangles(const std::vector<Triangle>& triangles,
+std::vector<const BasicTriangle*> find_all_triangles(const std::vector<BasicTriangle>& triangles,
                                                 const std::array<Vector3, 2>& bounds);
 
-std::vector<const Triangle*> find_all_triangles(const std::vector<const Triangle*>& triangles,
+std::vector<const BasicTriangle*> find_all_triangles(const std::vector<const BasicTriangle*>& triangles,
                                                 const std::array<Vector3, 2>& bounds);
 
 

--- a/raytracer/include/octree/octree.hxx
+++ b/raytracer/include/octree/octree.hxx
@@ -30,9 +30,7 @@ Octree* Octree::build_octree(const T& triangles,
     {
       if (depth == 0 || part_triangles.size() < optimal_by_node)
       {
-        std::unique_ptr<Leaf> leaf = std::make_unique<Leaf>();
-        leaf->triangles = part_triangles;
-        leaf->bounds = bnds;
+        std::unique_ptr<Leaf> leaf = std::make_unique<Leaf>(part_triangles, bnds);
         tree->children[i] = std::move(leaf);
       }
       else

--- a/raytracer/include/octree/octree.hxx
+++ b/raytracer/include/octree/octree.hxx
@@ -22,7 +22,7 @@ Octree* Octree::build_octree(const T& triangles,
       bounds[0].getZ() + ((i & 4) >> 2) * mid.getZ()
     );
     bnds[1] = bnds[0] + mid;
-    std::vector<const Triangle*> part_triangles = find_all_triangles(triangles, bnds);
+    std::vector<const BasicTriangle*> part_triangles = find_all_triangles(triangles, bnds);
 
     if (part_triangles.empty())
       tree->children[i] = nullptr;

--- a/raytracer/include/triangle.hh
+++ b/raytracer/include/triangle.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "shape.hh"
+#include "basic_triangle.hh"
 
 class Triangle: public Shape
 {
@@ -14,15 +15,14 @@ public:
   virtual Vector3 normal_vect(const Vector3& intersect) const override;
   bool inside(const std::array<Vector3, 2> bounds) const;
 
-  friend std::istream& operator>>(std::istream& is, Triangle& sphere);
-  friend std::ostream& operator<<(std::ostream& is, const Triangle& sphere);
+  friend std::istream& operator>>(std::istream& is, Triangle& triangle);
+  friend std::ostream& operator<<(std::ostream& is, const Triangle& triangle);
 
 protected:
   virtual std::ostream& display(std::ostream& os) const override;
 
 private:
-  Vector3 b;
-  Vector3 c;
+  BasicTriangle triangle;
 };
 
 std::istream& operator>>(std::istream& is, Triangle& sphere);

--- a/raytracer/src/basic_triangle.cc
+++ b/raytracer/src/basic_triangle.cc
@@ -5,7 +5,6 @@ std::istream& operator>>(std::istream& is, BasicTriangle& triangle)
   return is >> triangle.a >> triangle.b >> triangle.c;
 }
 
-
 std::ostream& operator<<(std::ostream& os, const BasicTriangle& triangle)
 {
   return os << triangle.a << " " << triangle.b << " " << triangle.c;

--- a/raytracer/src/basic_triangle.cc
+++ b/raytracer/src/basic_triangle.cc
@@ -1,0 +1,12 @@
+#include "basic_triangle.hh"
+
+std::istream& operator>>(std::istream& is, BasicTriangle& triangle)
+{
+  return is >> triangle.a >> triangle.b >> triangle.c;
+}
+
+
+std::ostream& operator<<(std::ostream& os, const BasicTriangle& triangle)
+{
+  return os << triangle.a << " " << triangle.b << " " << triangle.c;
+}

--- a/raytracer/src/box.cc
+++ b/raytracer/src/box.cc
@@ -18,13 +18,13 @@ void Box::calculate_bounds()
     pos - half_scale,
     pos + half_scale
   }};
-  calculate_box_triangles(bounds, triangles, attr, color);
+  calculate_box_triangles(bounds, triangles);
 }
 
 Vector3 Box::intersect(const Ray& ray) const
 {
-  std::pair<Vector3, const Triangle*> pair = find_closest_intersection(triangles, ray);
-  const_cast<std::map<Vector3, const Triangle*>&>(intersect_to_triangle).insert(pair);
+  std::pair<Vector3, const BasicTriangle*> pair = find_closest_intersection(triangles, ray);
+  const_cast<std::map<Vector3, const BasicTriangle*>&>(intersect_to_triangle).insert(pair);
   return pair.first;
 }
 
@@ -44,7 +44,7 @@ Vector3 Box::normal_vect(const Vector3& intersect) const
 {
   auto triangle = intersect_to_triangle.find(intersect);
   if (triangle != intersect_to_triangle.end())
-    return triangle->second->normal_vect(intersect);
+    return triangle->second->normal_vect();
 
   return intersect - pos;
 }
@@ -54,13 +54,14 @@ std::ostream& Box::display(std::ostream& os) const
   return os << *this;
 }
 
-Vector3 box_intersect(const std::array<Triangle, 12>& triangles, const Ray& ray)
+Vector3 box_intersect(const std::array<BasicTriangle, 12>& triangles, const Ray& ray)
 {
   auto pair = find_closest_intersection(triangles, ray);
   return pair.first;
 }
 
-void calculate_box_triangles(const std::array<Vector3, 2>& bounds, std::array<Triangle, 12>& triangles, const Attributes& attr, const Color& color)
+void calculate_box_triangles(const std::array<Vector3, 2>& bounds,
+                            std::array<BasicTriangle, 12>& triangles)
 {
   std::array<Vector3, 8> vertices {{
     bounds[0],
@@ -73,18 +74,18 @@ void calculate_box_triangles(const std::array<Vector3, 2>& bounds, std::array<Tr
     bounds[1]
   }};
   triangles = {{
-    { Triangle(vertices[0], vertices[2], vertices[4], attr, color) }, // front
-    { Triangle(vertices[2], vertices[4], vertices[6], attr, color) },
-    { Triangle(vertices[0], vertices[1], vertices[2], attr, color) }, // left
-    { Triangle(vertices[1], vertices[2], vertices[3], attr, color) },
-    { Triangle(vertices[0], vertices[1], vertices[4], attr, color) }, // bottom
-    { Triangle(vertices[1], vertices[4], vertices[5], attr, color) },
-    { Triangle(vertices[4], vertices[5], vertices[6], attr, color) }, // right
-    { Triangle(vertices[5], vertices[6], vertices[7], attr, color) },
-    { Triangle(vertices[1], vertices[3], vertices[7], attr, color) }, // back
-    { Triangle(vertices[1], vertices[7], vertices[5], attr, color) },
-    { Triangle(vertices[2], vertices[3], vertices[6], attr, color) }, // top
-    { Triangle(vertices[3], vertices[6], vertices[7], attr, color) }
+    { BasicTriangle(vertices[0], vertices[2], vertices[4]) }, // front
+    { BasicTriangle(vertices[2], vertices[4], vertices[6]) },
+    { BasicTriangle(vertices[0], vertices[1], vertices[2]) }, // left
+    { BasicTriangle(vertices[1], vertices[2], vertices[3]) },
+    { BasicTriangle(vertices[0], vertices[1], vertices[4]) }, // bottom
+    { BasicTriangle(vertices[1], vertices[4], vertices[5]) },
+    { BasicTriangle(vertices[4], vertices[5], vertices[6]) }, // right
+    { BasicTriangle(vertices[5], vertices[6], vertices[7]) },
+    { BasicTriangle(vertices[1], vertices[3], vertices[7]) }, // back
+    { BasicTriangle(vertices[1], vertices[7], vertices[5]) },
+    { BasicTriangle(vertices[2], vertices[3], vertices[6]) }, // top
+    { BasicTriangle(vertices[3], vertices[6], vertices[7]) }
   }};
 }
 

--- a/raytracer/src/mesh.cc
+++ b/raytracer/src/mesh.cc
@@ -7,7 +7,7 @@
 #include <array>
 
 Mesh::Mesh(const Vector3& pos, const Attributes& attr, const Color& color,
-          const std::vector<Triangle>& triangles)
+          const std::vector<BasicTriangle>& triangles)
        : Shape(pos, attr, color), triangles(triangles)
 {
   calculate_bounds();
@@ -25,7 +25,7 @@ void Mesh::calculate_bounds()
               std::numeric_limits<double>::min(),
               std::numeric_limits<double>::min())
     }};
-    for (const Triangle& triangle: triangles)
+    for (const BasicTriangle& triangle: triangles)
     {
       std::array<Vector3, 3> vertices = triangle.get_vertices();
       for (Vector3 vertex: vertices)
@@ -46,9 +46,9 @@ Vector3 Mesh::intersect(const Ray& ray) const
 {
   if (octree)
   {
-    std::vector<const Triangle*> t = octree->intersect(ray);
+    std::vector<const BasicTriangle*> t = octree->intersect(ray);
     auto pair = find_closest_intersection_ptr(t, ray);
-    const_cast<std::map<Vector3, const Triangle*>&>(intersect_to_triangle).insert(pair);
+    const_cast<std::map<Vector3, const BasicTriangle*>&>(intersect_to_triangle).insert(pair);
     return pair.first;
   }
   return Vector3();
@@ -56,8 +56,9 @@ Vector3 Mesh::intersect(const Ray& ray) const
 
 std::istream& operator>>(std::istream& is, Mesh& mesh)
 {
-  is >> std::quoted(mesh.name);
+  is >> std::quoted(mesh.name) >> mesh.attr >> mesh.color;
   std::string field;
+
   while (is >> field)
   {
     if (field == "end")
@@ -65,15 +66,10 @@ std::istream& operator>>(std::istream& is, Mesh& mesh)
 
     if (field == "triangle")
     {
-      Triangle triangle;
+      BasicTriangle triangle;
       is >> triangle;
       mesh.triangles.push_back(triangle);
     }
-  }
-  if (mesh.triangles.size() > 0)
-  {
-    mesh.attr = mesh.triangles[0].get_attributes();
-    mesh.color = mesh.triangles[0].get_color();
   }
   mesh.calculate_bounds();
   return is;
@@ -82,14 +78,15 @@ std::istream& operator>>(std::istream& is, Mesh& mesh)
 std::ostream& operator<<(std::ostream& os, const Mesh& mesh)
 {
   return os << "Mesh: " << mesh.name << ": triangle count: "
-            << mesh.triangles.size() << " attr: " << mesh.attr << " color: " << mesh.color;
+            << mesh.triangles.size() << " attr: " << mesh.attr << " color: "
+            << mesh.color;
 }
 
 Vector3 Mesh::normal_vect(const Vector3& intersect) const
 {
   auto triangle = intersect_to_triangle.find(intersect);
   if (triangle != intersect_to_triangle.end())
-    return triangle->second->normal_vect(intersect);
+    return triangle->second->normal_vect();
 
   return pos - intersect;
 }

--- a/raytracer/src/octree/leaf.cc
+++ b/raytracer/src/octree/leaf.cc
@@ -2,7 +2,7 @@
 #include "box.hh"
 
 void Leaf::intersect(const Ray& ray,
-                     std::vector<const Triangle*>& triangles) const
+                     std::vector<const BasicTriangle*>& triangles) const
 {
   if (box_is_intersecting(ray, bounds))
     triangles.insert(triangles.end(), this->triangles.begin(), this->triangles.end());

--- a/raytracer/src/octree/leaf.cc
+++ b/raytracer/src/octree/leaf.cc
@@ -7,3 +7,8 @@ void Leaf::intersect(const Ray& ray,
   if (box_is_intersecting(ray, bounds))
     triangles.insert(triangles.end(), this->triangles.begin(), this->triangles.end());
 }
+
+Leaf::Leaf(const std::vector<const BasicTriangle*>& triangles,
+           const std::array<Vector3, 2>& bounds)
+     : Node(bounds), triangles(triangles)
+{}

--- a/raytracer/src/octree/node.cc
+++ b/raytracer/src/octree/node.cc
@@ -1,0 +1,5 @@
+#include "octree/node.hh"
+
+Node::Node(const std::array<Vector3, 2>& bounds)
+     : bounds(bounds)
+{}

--- a/raytracer/src/octree/octree.cc
+++ b/raytracer/src/octree/octree.cc
@@ -5,31 +5,31 @@
 #include <iterator>
 #include <memory>
 
-std::vector<const Triangle*> find_all_triangles(const std::vector<Triangle>& triangles,
+std::vector<const BasicTriangle*> find_all_triangles(const std::vector<BasicTriangle>& triangles,
                                                 const std::array<Vector3, 2>& bounds)
 {
-  std::vector<const Triangle*> out;
-  for (const Triangle& triangle: triangles)
+  std::vector<const BasicTriangle*> out;
+  for (const BasicTriangle& triangle: triangles)
     if (triangle.inside(bounds))
       out.push_back(&triangle);
 
   return out;
 }
 
-std::vector<const Triangle*> find_all_triangles(const std::vector<const Triangle*>& triangles,
+std::vector<const BasicTriangle*> find_all_triangles(const std::vector<const BasicTriangle*>& triangles,
                                                 const std::array<Vector3, 2>& bounds)
 {
-  std::vector<const Triangle*> out;
-  for (const Triangle* triangle: triangles)
+  std::vector<const BasicTriangle*> out;
+  for (const BasicTriangle* triangle: triangles)
     if (triangle->inside(bounds))
       out.push_back(triangle);
 
   return out;
 }
 
-std::vector<const Triangle*> Octree::intersect(const Ray& ray) const
+std::vector<const BasicTriangle*> Octree::intersect(const Ray& ray) const
 {
-  std::vector<const Triangle*> triangles;
+  std::vector<const BasicTriangle*> triangles;
   intersect(ray, triangles);
   std::sort(triangles.begin(), triangles.end());
   triangles.erase(std::unique(triangles.begin(), triangles.end()), triangles.end());
@@ -37,7 +37,7 @@ std::vector<const Triangle*> Octree::intersect(const Ray& ray) const
 }
 
 void Octree::intersect(const Ray& ray,
-                       std::vector<const Triangle*>& triangles) const
+                       std::vector<const BasicTriangle*>& triangles) const
 {
   if (!box_is_intersecting(ray, bounds))
     return;

--- a/raytracer/src/triangle.cc
+++ b/raytracer/src/triangle.cc
@@ -7,67 +7,35 @@
 
 Triangle::Triangle(const Vector3& a, const Vector3& b, const Vector3& c,
                    const Attributes& attr, const Color& color)
-      : Shape(a, attr, color), b(b), c(c)
+      : Shape(a, attr, color), triangle(a, b, c)
 {}
 
 Vector3 Triangle::normal_vect(const Vector3&) const
 {
-  const Vector3& a = pos;
-  Vector3 ab = b - a;
-  Vector3 ac = c - a;
-  return ab * ac;
+  return triangle.normal_vect();
 }
 
 std::array<Vector3, 3> Triangle::get_vertices() const
 {
-  std::array<Vector3, 3> vertices {{ pos, b, c }};
-  return vertices;
+  return triangle.get_vertices();
 }
 
 // Use Möller-Trumbore intersection algorithm
 Vector3 Triangle::intersect(const Ray& ray) const
 {
-  const Vector3& a = pos;
-
-  Vector3 ab = b - a;
-  Vector3 ac = c - a;
-  Vector3 pvec = ray.direction * ac;
-  double determinant = ab.dot_product(pvec);
-
-  if (std::abs(determinant) < epsilon)
-    return Vector3();
-
-  double inverse_determinant = 1. / determinant;
-
-  Vector3 tvec = ray.position - a;
-  double u = tvec.dot_product(pvec) * inverse_determinant;
-  if (u < 0 || u > 1)
-    return Vector3();
-
-  Vector3 qvec = tvec * ab;
-  double v = ray.direction.dot_product(qvec) * inverse_determinant;
-  if (v < 0 || u + v > 1)
-    return Vector3();
-
-  double t = ac.dot_product(qvec) * inverse_determinant;
-
-  if (t > epsilon)
-    return ray.direction * t + ray.position;
-
-  return Vector3();
+  return triangle.intersect(ray);
 }
 
 std::istream& operator>>(std::istream& is, Triangle& triangle)
 {
-  return is >> std::quoted(triangle.name) >> triangle.pos >> triangle.b
-            >> triangle.c >> triangle.attr >> triangle.color;
+  return is >> std::quoted(triangle.name) >> triangle.triangle
+            >> triangle.attr >> triangle.color;
 }
 
 std::ostream& operator<<(std::ostream& os, const Triangle& triangle)
 {
-  return os << "Triangle: " << triangle.name << " Pos: " << triangle.pos << " "
-            << triangle.b << " " << triangle.c << " " << triangle.attr
-            << " Color: " << triangle.color;
+  return os << "Triangle: " << triangle.name << " Pos: " << triangle.triangle
+            << " " << triangle.attr << " Color: " << triangle.color;
 }
 
 std::ostream& Triangle::display(std::ostream& os) const
@@ -77,5 +45,5 @@ std::ostream& Triangle::display(std::ostream& os) const
 
 bool Triangle::inside(const std::array<Vector3, 2> bounds) const
 {
-  return pos.inside(bounds) || b.inside(bounds) || c.inside(bounds);
+  return triangle.inside(bounds);
 }

--- a/src/model/Mesh.java
+++ b/src/model/Mesh.java
@@ -85,6 +85,7 @@ public class Mesh extends Shape {
                   .append(point3D.getY() * scaleY + translateY).append(" ")
                   .append(point3D.getZ() * scaleZ + translateZ).append(" ");
             }
+            sb.append("\n");
         }
 
         return sb.append("end").toString();

--- a/src/model/Mesh.java
+++ b/src/model/Mesh.java
@@ -62,7 +62,6 @@ public class Mesh extends Shape {
 
     @Override
     public String toString() {
-        int triangle = 0;
         StringBuilder sb = new StringBuilder();
         String colorString = getColorString(color);
         String attributeString = attributes.toString();
@@ -75,10 +74,10 @@ public class Mesh extends Shape {
         double translateY = internalMesh.getTranslateY();
         double translateZ = internalMesh.getTranslateZ();
 
-        sb.append("mesh \"").append(name).append("\"\n");
+        sb.append("mesh \"").append(name).append("\" ").append(attributeString).append(" ").append(colorString).append("\n");
 
         for (ObjReader.Face face: faces) {
-            sb.append("triangle \"").append(name).append(triangle++).append("\" ");
+            sb.append("triangle ");
 
             for (int i = 0; i < 3; i++) {
                 Point3D point3D = vertices.get(face.vertices[i * 2]);
@@ -86,7 +85,6 @@ public class Mesh extends Shape {
                   .append(point3D.getY() * scaleY + translateY).append(" ")
                   .append(point3D.getZ() * scaleZ + translateZ).append(" ");
             }
-            sb.append(attributeString).append(" ").append(colorString).append("\n");
         }
 
         return sb.append("end").toString();


### PR DESCRIPTION
* should speed up all memory copies
* should improve data locality
* should reduce memory consumption (a lot) of meshes
* removes duplicate attributes & color copied in mesh
* breaking change, parsing of Mesh is changed
  - old:
    mesh name
      triangle name a b c attr color
      ...
    end
  - new
    mesh name attr color
      triangle a b c
      ...
    end
  triangle names had no use at all and attributes and color were
duplicates across all lines